### PR TITLE
Fix typos 

### DIFF
--- a/assets/js/cookiesnotice.js
+++ b/assets/js/cookiesnotice.js
@@ -1,6 +1,6 @@
 (function($){
     $.showCookiesNotice = function(cookieText, linkHref, linkText, dismissText, cookieStyle) {
-        if ($.cookie('cookienotice')!='acctepted') {
+        if ($.cookie('cookienotice')!='accepted') {
             var cookieHtml = '<div class="cookienotice">';
                 cookieHtml += cookieText;
                 cookieHtml += '<div class="cookiewrap"></div><a href="'+linkHref+'">'+linkText+'</a>';
@@ -22,6 +22,6 @@
     };
     $.closeCookieNotice = function() {
         $("div.cookienotice").remove();
-        $.cookie('cookienotice', 'acctepted', { expires: 365, path: '/' });
+        $.cookie('cookienotice', 'accepted', { expires: 365, path: '/' });
     };
 })(jQuery);

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -36,9 +36,9 @@ form:
           type: bool
         help: 'The jQuery Cookie PLugin v1.4.1 has to be loaded. If an error occurs, load it manually.'
 
-      possition:
+      position:
         type: select
-        label: Possition
+        label: Position
         size: small
         default: top
         options:

--- a/cookiesnotice.php
+++ b/cookiesnotice.php
@@ -50,7 +50,7 @@ class CookiesNoticePlugin extends Plugin
 
         $twig = $this->grav['twig'];
         $twig->twig_vars['cookiesnotice_markup'] = $twig->twig->render('partials/cookiesnotice.html.twig', array(
-            'cookiesnotice_possition' => strtolower($this->config->get('plugins.cookiesnotice.possition')),
+            'cookiesnotice_position' => strtolower($this->config->get('plugins.cookiesnotice.position')),
             'cookiesnotice_url' => $this->config->get('plugins.cookiesnotice.url')
         ));
     }

--- a/templates/partials/cookiesnotice.html.twig
+++ b/templates/partials/cookiesnotice.html.twig
@@ -1,5 +1,5 @@
 <script>
 	$(document).ready(function() {
- 		$.showCookiesNotice("{{ 'PLUGINS.COOKIES_NOTICE.COOKIE'|t }}", "{{ cookiesnotice_url }}", "{{ 'PLUGINS.COOKIES_NOTICE.LINK'|t }}", "{{ 'PLUGINS.COOKIES_NOTICE.DIMISS'|t }}", "{{ cookiesnotice_possition }}");
+ 		$.showCookiesNotice("{{ 'PLUGINS.COOKIES_NOTICE.COOKIE'|t }}", "{{ cookiesnotice_url }}", "{{ 'PLUGINS.COOKIES_NOTICE.LINK'|t }}", "{{ 'PLUGINS.COOKIES_NOTICE.DIMISS'|t }}", "{{ cookiesnotice_position }}");
  	});
 </script>


### PR DESCRIPTION
There were few typos that got passed in to the code. They are now fixed. This will reset end user preferences and the banner will be displayed again since the typo was in the cookie value. 